### PR TITLE
Update CoreAudio to 1.17.0

### DIFF
--- a/src/HASS.Agent.Shared/HASS.Agent.Shared.csproj
+++ b/src/HASS.Agent.Shared/HASS.Agent.Shared.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="ByteSize" Version="2.1.1" />
     <PackageReference Include="Cassia.NetStandard" Version="1.0.0" />
     <PackageReference Include="CliWrap" Version="3.4.4" />
-    <PackageReference Include="CoreAudio" Version="1.12.0" />
+    <PackageReference Include="CoreAudio" Version="1.17.0" />
     <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="Microsoft.Win32.SystemEvents" Version="6.0.1" />

--- a/src/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/AudioSensors.cs
+++ b/src/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/MultiValue/AudioSensors.cs
@@ -110,7 +110,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
             {
                 var errors = false;
 
-                foreach (var device in Variables.AudioDeviceEnumerator.EnumerateAudioEndPoints(EDataFlow.eRender, DEVICE_STATE.DEVICE_STATE_ACTIVE))
+                foreach (var device in Variables.AudioDeviceEnumerator.EnumerateAudioEndPoints(EDataFlow.eRender, DeviceState.Active))
                 {
                     // process sessions (and get peak volume)
                     foreach (var session in device.AudioSessionManager2?.Sessions.Where(x => x != null))
@@ -202,15 +202,15 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.MultiValue
         /// </summary>
         /// <param name="state"></param>
         /// <returns></returns>
-        private static string GetReadableState(DEVICE_STATE state)
+        private static string GetReadableState(DeviceState state)
         {
             return state switch
             {
-                DEVICE_STATE.DEVICE_STATE_ACTIVE => "ACTIVE",
-                DEVICE_STATE.DEVICE_STATE_DISABLED => "DISABLED",
-                DEVICE_STATE.DEVICE_STATE_NOTPRESENT => "NOT PRESENT",
-                DEVICE_STATE.DEVICE_STATE_UNPLUGGED => "UNPLUGGED",
-                DEVICE_STATE.DEVICE_STATEMASK_ALL => "STATEMASK_ALL",
+                DeviceState.Active => "ACTIVE",
+                DeviceState.Dsiabled => "DISABLED",
+                DeviceState.NotPresent => "NOT PRESENT",
+                DeviceState.Unplugged => "UNPLUGGED",
+                DeviceState.MaskAll => "STATEMASK_ALL",
                 _ => "UNKNOWN"
             };
         }


### PR DESCRIPTION
Updating `CoreAudio` to 1.17.0 will provide full Audio Device friendly names (eg. `Speakers (Realtek(R) Audio)` instead of just `Realtek(R) Audio` as mentioned in [#44](https://github.com/LAB02-Research/HASS.Agent/issues/44)